### PR TITLE
Update requests version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-requests==2.10.0
+requests==2.20.0

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ def read(file_name):
 
 setup(
     name="encodingcom",
-    version="0.1.2",
+    version="0.1.6",
     description="Python 3 wrapper for Encoding.com api",
     license="",
     keywords="encoding.com transcoding",
@@ -19,7 +19,7 @@ setup(
     long_description='Encoding.com service handling (c) StudioNow 2015',
     include_package_data=True,
     install_requires=[
-        'requests>=2.5.1'
+        'requests>=2.20.0'
     ],
     data_files = ['README.md'],
     classifiers=[


### PR DESCRIPTION
Updated `requests` version because of this moderate severity issue:

## CVE-2018-18074
### Vulnerable versions: <= 2.19.1
### Patched version: 2.20.0
The Requests package through 2.19.1 before 2018-09-14 for Python sends an HTTP Authorization header to an http URI upon receiving a same-hostname https-to-http redirect, which makes it easier for remote attackers to discover credentials by sniffing the network.